### PR TITLE
Cleanup: Updated documentation URLs

### DIFF
--- a/_resource/overrides/partials/header.html
+++ b/_resource/overrides/partials/header.html
@@ -3,7 +3,7 @@
 -#}
 <header class="md-header" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header.title') }}">
-    <a href="https://percona.com/software/documentation" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+    <a href="https://docs.percona.com/" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
       {% include "partials/logo.html" %}
     </a>
     <label class="md-header__button md-icon" for="__drawer">
@@ -12,7 +12,7 @@
     <div class="md-header__title" data-md-component="header-title">
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
-          <span class="md-ellipsis"><a href="https://www.percona.com/software/documentation">
+          <span class="md-ellipsis"><a href="https://docs.percona.com/">
             Percona Product Documentation
           </a></span>
         </div>

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -89,5 +89,5 @@ Next, use the operating system's package management tool to install the desired 
     * [Percona Server for MySQL](https://docs.percona.com/percona-server/latest/installation/yum_repo.html)
     * [Percona Server for MongoDB](https://docs.percona.com/percona-server-for-mongodb/latest/install/yum.html)
     * [Percona XtraBackup](https://docs.percona.com/percona-xtrabackup/latest/installation/yum_repo.html)
-    * [Percona XtraDB Cluster](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/install/yum.html)
+    * [Percona XtraDB Cluster](https://docs.percona.com/percona-xtrabackup/latest/index.html)
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -72,22 +72,22 @@ Next, use the operating system's package management tool to install the desired 
 
 === "Debian and Ubuntu with the `apt` package manager"
 
-    * [Percona Distribution for MongoDB](https://www.percona.com/doc/percona-distribution-for-mongodb/LATEST/installation.html#install-on-debian-ubuntu)
-    * [Percona Distribution for MySQL](https://www.percona.com/doc/percona-distribution-mysql/8.0/installing.html#install-pdmysql)
-    * [Percona Distribution for PostgreSQL](https://www.percona.com/doc/postgresql/LATEST/installing.html#on-debian-and-ubuntu-using-apt)
-    * [Percona Server for MySQL](https://www.percona.com/doc/percona-server/LATEST/installation/apt_repo.html)
-    * [Percona Server for MongoDB](https://www.percona.com/doc/percona-server-for-mongodb/LATEST/install/apt.html)
-    * [Percona XtraBackup](https://www.percona.com/doc/percona-xtrabackup/LATEST/installation/apt_repo.html)
+    * [Percona Distribution for MongoDB](https://docs.percona.com/percona-distribution-for-mongodb/latest/installation.html#install-on-debian-ubuntu)
+    * [Percona Distribution for MySQL](https://docs.percona.com/percona-distribution-for-mysql/8.0/installing.html#install-pdmysql)
+    * [Percona Distribution for PostgreSQL](https://docs.percona.com/postgresql/14/installing.html#on-debian-and-ubuntu-using-apt)
+    * [Percona Server for MySQL](https://docs.percona.com/percona-server/latest/installation/apt_repo.html)
+    * [Percona Server for MongoDB](https://docs.percona.com/percona-server-for-mongodb/latest/install/apt.html)
+    * [Percona XtraBackup](https://docs.percona.com/percona-xtrabackup/latest/installation/apt_repo.html)
     * [Percona XtraDB Cluster](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/install/apt.html)
 
 
 === "Red Hat Enterprise Linux and derivatives with the `yum` package manager"
 
-    * [Percona Distribution for MongoDB](https://www.percona.com/doc/percona-distribution-for-mongodb/LATEST/installation.html#install-on-red-hat-enterprise-linux-centos)
-    * [Percona Distribution for MySQL](https://www.percona.com/doc/percona-distribution-mysql/8.0/installing.html#install-pdmysql)
-    * [Percona Distribution for PostgreSQL](https://www.percona.com/doc/postgresql/LATEST/installing.html#on-red-hat-enterprise-linux-and-centos-using-yum)
-    * [Percona Server for MySQL](https://www.percona.com/doc/percona-server/LATEST/installation/yum_repo.html)
-    * [Percona Server for MongoDB](https://www.percona.com/doc/percona-server-for-mongodb/LATEST/install/yum.html)
-    * [Percona XtraBackup](https://www.percona.com/doc/percona-xtrabackup/LATEST/installation/yum_repo.html)
+    * [Percona Distribution for MongoDB](https://docs.percona.com/percona-distribution-for-mongodb/latest/installation.html#install-on-red-hat-enterprise-linux-centos)
+    * [Percona Distribution for MySQL](https://docs.percona.com/percona-distribution-for-mysql/8.0/installing.html#install-pdmysql)
+    * [Percona Distribution for PostgreSQL](https://docs.percona.com/postgresql/14/installing.html#on-red-hat-enterprise-linux-and-centos-using-yum)
+    * [Percona Server for MySQL](https://docs.percona.com/percona-server/latest/installation/yum_repo.html)
+    * [Percona Server for MongoDB](https://docs.percona.com/percona-server-for-mongodb/latest/install/yum.html)
+    * [Percona XtraBackup](https://docs.percona.com/percona-xtrabackup/latest/installation/yum_repo.html)
     * [Percona XtraDB Cluster](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/install/yum.html)
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -78,7 +78,7 @@ Next, use the operating system's package management tool to install the desired 
     * [Percona Server for MySQL](https://docs.percona.com/percona-server/latest/installation/apt_repo.html)
     * [Percona Server for MongoDB](https://docs.percona.com/percona-server-for-mongodb/latest/install/apt.html)
     * [Percona XtraBackup](https://docs.percona.com/percona-xtrabackup/latest/installation/apt_repo.html)
-    * [Percona XtraDB Cluster](https://www.percona.com/doc/percona-xtradb-cluster/LATEST/install/apt.html)
+    * [Percona XtraDB Cluster](https://docs.percona.com/percona-xtrabackup/latest/index.html)
 
 
 === "Red Hat Enterprise Linux and derivatives with the `yum` package manager"

--- a/mkdocs-percona.yml
+++ b/mkdocs-percona.yml
@@ -5,7 +5,7 @@ site_description: Documentation
 site_author: Percona LLC
 copyright: Percona LLC, &#169; 2021
 
-site_url: 'https://www.percona.com/doc/percona-repo-config/'
+site_url: 'https://docs.percona.com/percona-software-repositories/'
 repo_name: /percona/repo-config-docs
 repo_url: https://github.com/percona/repo-config-docs
 edit_uri: edit/master/docs/


### PR DESCRIPTION
Updated documentation URLs in the installation instructions to point to their new location on https://docs.percona.com/

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>