### PR TITLE
DOCS-342 - Update percona-release show command

### DIFF
--- a/docs/percona-release.md
+++ b/docs/percona-release.md
@@ -33,6 +33,9 @@ The command shows the enabled repositories in your system:
 $ sudo percona-release show
 ```
 
+!!! note
+    The command shows enabled repositories, not available packages.
+
 #### `enable`
 
 The command turns on an additional Percona [repository location](repository-location.md).

--- a/docs/percona-release.md
+++ b/docs/percona-release.md
@@ -19,15 +19,10 @@ Run all commands as the root user or via `sudo`.
 Available commands are [enable](#enable), [enable-only](#enable-only), [disable](#disable), [setup](#setup) and [show](#show).
 
 !!! important
-
     The `telemetry` repository is enabled by default.
-
     Other Percona repositories are not enabled automatically beyond the selected product repository.
-
     Commands such as `enable-only` and `setup` disable other repositories.
-
     If required repositories are not enabled, package installation may fail or result in missing dependencies.
-
     Ensure that all required repositories for your environment are explicitly enabled.
 
 #### `show`
@@ -70,9 +65,7 @@ $ sudo percona-release disable all
 ```
 
 !!! note
-
     The `prel` repository remains enabled. This repository stores the `percona-release` packages and is always enabled for `percona-release` to operate.
-
 
 #### `setup`
 
@@ -121,7 +114,6 @@ $ sudo percona-release enable ps-84-lts release --scheme https
 If no `--scheme` flag is specified, the default HTTP protocol is used. 
 
 You can use this flag with the `enable`, `enable-only`, `disable`, and `setup` commands.
-
 
 ## Examples: All steps for installing a specific Percona product
 

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -3,16 +3,15 @@
 ## Percona Distribution for PostgreSQL
 
 === "Version 17"
-    
+
     | Repository    | Product Packages                            |
     | ------------- | ------------------------------------------- |
     | `ppg-17`      | Percona Distribution for PostgreSQL 17      |
     | `ppg-17.2`    | Percona Distribution for PostgreSQL 17.2.1  |
     | `ppg-17.0`    | Percona Distribution for PostgreSQL 17.0.1  |
 
-
 === "Version 16"
-    
+
     | Repository    | Product Packages                          |
     | ------------- | ----------------------------------------- |
     | `ppg-16`      | Percona Distribution for PostgreSQL 16    |
@@ -24,7 +23,7 @@
     | `ppg-16.0`    | Percona Distribution for PostgreSQL 16.0  |
 
 === "Version 15"
-    
+
     | Repository    | Product Packages                          |
     | ------------- | ----------------------------------------- |
     | `ppg-15`      | Percona Distribution for PostgreSQL 15    |
@@ -40,7 +39,7 @@
     | `ppg-15.0`    | Percona Distribution for PostgreSQL 15.0  |
 
 === "Version 14"
-    
+
     | Repository    | Product Packages                          |
     | ------------- | ----------------------------------------- |
     | `ppg-14`      | Percona Distribution for PostgreSQL 14    |
@@ -59,7 +58,7 @@
     | `ppg-14.2`    | Percona Distribution for PostgreSQL 14.2  |
     | `ppg-14.1`    | Percona Distribution for PostgreSQL 14.1  |
 
-=== "Version 13"
+=== "Version 13 (EOL)"
 
     | Repository    | Product Packages                          |
     | ------------- | ----------------------------------------- |
@@ -83,8 +82,8 @@
     | `ppg-13.1`    | Percona Distribution for PostgreSQL 13.1  |
     | `ppg-13.0`    | Percona Distribution for PostgreSQL 13.0  |
 
-=== "Version 12"
-    
+=== "Version 12 (EOL)"
+
     | Repository    | Product Packages                          |
     | ------------- | ----------------------------------------- |
     | `ppg-12`      | Percona Distribution for PostgreSQL 12    |

--- a/docs/repository-location.md
+++ b/docs/repository-location.md
@@ -29,4 +29,3 @@ $ sudo percona-release enable ps-84-lts testing
 ```
 
 This example enables installing a pre-release version of Percona Server for MySQL 8.4.
-


### PR DESCRIPTION
This PR adds a note informing the user that the percona-release show command shows enabled repos, not available packages.